### PR TITLE
Add support for most pt-online-schema-change config options

### DIFF
--- a/lib/percona_migrations.rb
+++ b/lib/percona_migrations.rb
@@ -4,13 +4,74 @@ require 'percona_migrations/helper_methods'
 
 require 'active_record'
 require 'logger'
+require 'shellwords'
 
 module PerconaMigrations
   extend self
 
   @allow_sql = true
 
+  @config = Struct.new('PerconaConfig',
+                       :charset,
+                       :check_interval,
+                       :check_alter,
+                       :check_plan,
+                       :check_replication_filters,
+                       :check_slave_lag,
+                       :chunk_index,
+                       :chunk_index_columns,
+                       :chunk_size,
+                       :chunk_size_limit,
+                       :chunk_time,
+                       :critical_load,
+                       :default_engine,
+                       :defaults_file,
+                       :drop_new_table,
+                       :drop_old_table,
+                       :lock_wait_timeout,
+                       :max_lag,
+                       :max_load,
+                       :pid,
+                       :print,
+                       :progress,
+                       :quiet,
+                       :recurse,
+                       :recursion_method,
+                       :retries,
+                       :set_vars,
+                       :statistics,
+                       :swap_tables
+                       ).new
+
   attr_writer :database_config, :allow_sql, :logger
+
+  def config
+    if block_given?
+      yield @config
+    else
+      @config
+    end
+  end
+
+  def pt_schema_tool_args
+
+    @config.members.map do |key|
+
+      arg = key.to_s.gsub(/_/,'-')
+      val = @config[key]
+
+      case val
+      when nil
+        nil
+      when true
+        "--#{arg}"
+      when false
+        "--no-#{arg}"
+      else
+        "--#{arg} #{Shellwords.escape(val)}"
+      end
+    end.compact.join(' ')
+  end
 
   def database_config
     @database_config || raise('PerconaMigrations.database_config is not set.')

--- a/lib/percona_migrations/runners/percona.rb
+++ b/lib/percona_migrations/runners/percona.rb
@@ -13,6 +13,7 @@ module PerconaMigrations
 
       def run
         options = [
+          PerconaMigrations.pt_schema_tool_args,
           "--alter '#{@commands.join(', ')}'",
           "-h #{database_config['host']}",
           "-P #{database_config['port']}",
@@ -25,7 +26,7 @@ module PerconaMigrations
           options << "-p $PASSWORD"
         end
 
-        run_command(options.join(' '), { 'PASSWORD' => password })
+        run_command(options.reject(&:empty?).join(' '), { 'PASSWORD' => password })
       end
 
       private

--- a/spec/lib/percona_migrations/runners/percona_spec.rb
+++ b/spec/lib/percona_migrations/runners/percona_spec.rb
@@ -43,11 +43,12 @@ RSpec.describe PerconaMigrations::Runners::Percona do
 
     before do
       allow(PerconaMigrations).to receive(:database_config).and_return(db_config)
+      allow(PerconaMigrations).to receive(:pt_schema_tool_args).and_return('--foo')
       allow(subject).to receive(:percona_command).and_return(percona_command)
     end
 
     it 'runs percona command 2 times (dry-run and execute)' do
-      command = "#{percona_command} #{arguments.join(' ')}"
+      command = "#{percona_command} --foo #{arguments.join(' ')}"
 
       expect(runner).to receive(:system).
         with({ 'PASSWORD' => 'test' }, "#{command} --dry-run").
@@ -62,7 +63,7 @@ RSpec.describe PerconaMigrations::Runners::Percona do
 
     it 'throws an exception if dry-run fails' do
       expect(runner).to receive(:system).
-        with({ 'PASSWORD' => 'test' }, "#{percona_command} #{arguments.join(' ')} --dry-run").
+        with({ 'PASSWORD' => 'test' }, "#{percona_command} --foo #{arguments.join(' ')} --dry-run").
         and_return(false)
 
       expect { runner.run }.to raise_exception

--- a/spec/lib/percona_migrations_spec.rb
+++ b/spec/lib/percona_migrations_spec.rb
@@ -29,4 +29,45 @@ RSpec.describe PerconaMigrations do
       subject.database_config = nil
     end
   end
+
+  describe '::config' do
+    before do
+      subject.instance_eval { @config = @config.class.new }
+    end
+    it 'yields a block' do
+      expect { |b| subject.config(&b) }.to yield_control.once
+    end
+    it 'allows config to be set' do
+      subject.config { |c| c.max_load = 'Threads_running=25' }
+      expect(subject.config.max_load).to eq('Threads_running=25')
+    end
+    it 'ignores unset values' do
+      expect(subject.config.retries).to be(nil)
+    end
+    it 'returns no arguments by default' do
+      expect(subject.pt_schema_tool_args).to be_empty
+    end
+
+    context 'with boolean config' do
+      before do
+        subject.config do |c|
+          c.statistics = true
+          c.drop_old_table = false
+        end
+      end
+      it 'returns arguments' do
+        expect(subject.pt_schema_tool_args).to eq('--no-drop-old-table --statistics')
+      end
+    end
+    context 'with config' do
+      before do
+        subject.config do |c|
+          c.max_load = 'Threads_running=25'
+        end
+      end
+      it 'returns arguments' do
+        expect(subject.pt_schema_tool_args).to eq('--max-load Threads_running\\=25')
+      end
+    end
+  end
 end


### PR DESCRIPTION
**What it does**
There are additional tuning options for `pt-schema-online-change` that are worth supporting.

cf. https://www.percona.com/forums/questions-discussions/percona-toolkit/11746-pt-online-schema-change-showing-this-error-exceeds-its-critical-threshold-50

This adds support for most of those listed here:
https://www.percona.com/doc/percona-toolkit/2.1/pt-online-schema-change.html#cmdoption-pt-online-schema-change--lock-wait-timeout

**How it's implemented**
`PerconaMigrations.config` is a `Struct` with known arguments as members.  The values in the struct are turned into commandline arguments as follows:
- Nil values are ignored
- Booleans (e.g. `config.statistics = true`) are translated into `--arg` or `--no-arg` (e.g. `--statistics`)
- Other values are added as escaped values (e.g. `config.critical_load = 'Threads_running=100'`)

**Usage**
Anticipated usage in a rails initialiser, e.g.

``` ruby
PerconaMigrations.config do |c|
  c.critical_load = 'Threads_running=100'
end
```
